### PR TITLE
Customization

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -74,8 +74,6 @@ rules:
   react/jsx-uses-react:
     - 1
 extends: eslint:recommended
-ecmaFeatures:
-  jsx: true
-  experimentalObjectRestSpread: true
+parser: babel-eslint
 plugins:
   - react

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var minimist = require('minimist');
 var multiline = require('multiline');
 var path = require('path');
 var pkgConfig = require('pkg-config');
+var fs = require('fs');
 
 var opts = {
   version: require('./package.json').version,
@@ -69,8 +70,14 @@ if (argv.version) {
   process.exit(0);
 }
 
+var configFile = path.join(__dirname, '.eslintrc.yml');
+var localConfigFile = path.join(process.cwd(), '.eslintrc.yml');
+if (fs.existsSync(localConfigFile)) {
+  configFile = localConfigFile;
+}
+
 var cli = new CLIEngine({
-  configFile: path.join(__dirname, '.eslintrc.yml'),
+  configFile: configFile,
   extensions: ['.js', '.jsx'],
   envs: argv.env && argv.env.length ? argv.env : ['browser', 'mocha', 'node', 'commonjs', 'es6'],
   ignorePattern: ['node_modules/', '.git/', 'converage/', '*.min.js', 'dist/'].concat(argv.ignore || []),

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ var cli = new CLIEngine({
   configFile: configFile,
   extensions: ['.js', '.jsx'],
   envs: argv.env && argv.env.length ? argv.env : ['browser', 'mocha', 'node', 'commonjs', 'es6'],
-  ignorePattern: ['node_modules/', '.git/', 'converage/', '*.min.js', 'dist/'].concat(argv.ignore || []),
+  ignorePattern: ['node_modules/', '.git/', 'coverage/', '**/*.min.js', 'dist/'].concat(argv.ignore || []),
   fix: argv.fix || false,
   globals: argv.global && argv.global.length ? argv.global : []
 });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ var minimist = require('minimist');
 var multiline = require('multiline');
 var path = require('path');
 var pkgConfig = require('pkg-config');
-var fs = require('fs');
 
 var opts = {
   version: require('./package.json').version,
@@ -70,14 +69,8 @@ if (argv.version) {
   process.exit(0);
 }
 
-var configFile = path.join(__dirname, '.eslintrc.yml');
-var localConfigFile = path.join(process.cwd(), '.eslintrc.yml');
-if (fs.existsSync(localConfigFile)) {
-  configFile = localConfigFile;
-}
-
 var cli = new CLIEngine({
-  configFile: configFile,
+  configFile: path.join(__dirname, '.eslintrc.yml'),
   extensions: ['.js', '.jsx'],
   envs: argv.env && argv.env.length ? argv.env : ['browser', 'mocha', 'node', 'commonjs', 'es6'],
   ignorePattern: ['node_modules/', '.git/', 'coverage/', '**/*.min.js', 'dist/'].concat(argv.ignore || []),

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "lfeslint": "./index.js"
   },
   "dependencies": {
+    "babel-eslint": "^6.0.2",
     "eslint": "1.10.0",
     "eslint-plugin-react": "3.9.0",
-    "mout": "0.11.1",
     "minimist": "1.2.0",
+    "mout": "0.11.1",
     "multiline": "1.0.2",
     "pkg-config": "1.1.0"
   },


### PR DESCRIPTION
Checks the current working directory for an `.eslintrc.yml` and uses that instead of the default one if it exists. Presumably, that one will extend from the default lfeslint config. See https://github.com/storify/liveblog-editor/blob/lint/.eslintrc.yml.

Also fixes some ignore patterns, and uses `babel-eslint` for parsing, which enables some new ES6/7 features.