### PR TITLE
No space before any function params

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -16,7 +16,7 @@ rules:
     - "always"
   space-before-function-paren:
     - 2
-    - {named: "never", anonymous: "always"}
+    - never
   space-after-keywords:
     - 2
     - always


### PR DESCRIPTION
Currently, only anonymous functions have spaces before the parentheses. Named functions do not. I'd like to change that so that all functions have the same rules.

```javascript
// current
function named() {}
var anon = function () {}

// proposed
function named() {}
var anon = function() {}
```

Please vote using the emojis.