### PR TITLE
Preceding commas

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -36,7 +36,7 @@ rules:
     - 0
   comma-style:
     - 2
-    - last
+    - first
   no-irregular-whitespace:
     - 2
   eqeqeq:


### PR DESCRIPTION
If you have an extra comma in the end of the last line it will work in some browsers but not in all browsers. Making the error harder to detect (fail-fast).

Plus, having the comma at the beginning of the line, make it simpler to add a line at the end and you will have to touch only that line (you will not need to add the comma in the line before).

```
var obj = {
  abc: 'def'
  , ghi: 'jkl'
  , mno: 'pqr'
};
```
instead of:
```
var obj = {
  abc: 'def',
  ghi: 'jkl',
  mno: 'pqr'
};
```
Please use emojis to vote.