### PR TITLE
Add a couple rules for ES6 arrow functions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -75,6 +75,11 @@ rules:
     - 1
   eol-last:
     - 2
+  arrow-body-style:
+    - 2
+    - as-needed
+  arrow-spacing:
+    - 2
 extends: eslint:recommended
 parser: babel-eslint
 plugins:


### PR DESCRIPTION
```javascript
// Always put space around the arrow
arr.map(x => x * 2); // good
arr.map(x=>x * 2);   // bad

// No braces where they are not needed
arr.map(x => x * 2); // good
arr.map(x => {       // bad
  return x * 2;
});
```

There are a few more rules we could add once we upgrade eslint.