### PR TITLE
Require sorted imports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -87,17 +87,17 @@ rules:
     - always
   space-infix-ops:
     - 2
-  no-new-wrappers: 
+  no-new-wrappers:
     - 2
   no-self-compare:
     - 2
   no-nested-ternary:
     - 2
-  no-multiple-empty-lines: 
+  no-multiple-empty-lines:
     - 2
-  no-unneeded-ternary: 
+  no-unneeded-ternary:
     - 2
-  
+
   ## below rules are required to mimic eslint v1.0.0
   no-unsafe-finally:
     - off
@@ -106,29 +106,29 @@ rules:
   complexity:
     - off
     - 11
-  require-yield: 
+  require-yield:
     - 2
-  no-case-declarations: 
+  no-case-declarations:
     - 0
-  no-class-assign: 
+  no-class-assign:
     - 0
-  no-const-assign: 
+  no-const-assign:
     - 0
-  no-dupe-class-members: 
+  no-dupe-class-members:
     - 0
-  no-empty-pattern: 
+  no-empty-pattern:
     - 0
-  no-new-symbol: 
+  no-new-symbol:
     - 0
-  no-self-assign: 
+  no-self-assign:
     - 0
-  no-this-before-super: 
+  no-this-before-super:
     - 0
-  no-unexpected-multiline: 
+  no-unexpected-multiline:
     - 0
-  no-unused-labels: 
+  no-unused-labels:
     - 0
-  constructor-super: 
+  constructor-super:
     - 0
   no-compare-neg-zero:
     - off
@@ -136,13 +136,13 @@ rules:
     - off
   no-undef:
     - off
-  
+
   ## Below are rules that are needed for linter functionality when using React
   react/display-name:
     - 0
   react/jsx-closing-bracket-location:
     - 0
-  react/jsx-curly-spacing: 
+  react/jsx-curly-spacing:
     - 2
     - "never"
   react/jsx-indent-props:
@@ -179,10 +179,15 @@ rules:
     - 2
   react/require-extension:
     - 0
-    
+
+  # Custom rules
+  sort-imports:
+    - 2
+    - always
+
 plugins:
   - react
-extends: 
+extends:
   - eslint:recommended
 parser: babel-eslint
 parserOptions:

--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ var cli = new CLIEngine({
   envs: argv.env && argv.env.length ? argv.env : ['browser', 'mocha', 'node', 'commonjs', 'es6'],
   ignorePattern: ['node_modules/', '.git/', 'coverage/', '**/*.min.js', 'dist/'].concat(argv.ignore || []),
   fix: argv.fix || false,
-  globals: argv.global && argv.global.length ? argv.global : []
+  globals: argv.global && argv.global.length ? argv.global : [],
+  rulePaths: [path.join(__dirname, 'rules')]
 });
 
 var report = cli.executeOnFiles(argv._.length ? argv._ : ['./']);

--- a/rules/sort-imports.js
+++ b/rules/sort-imports.js
@@ -1,0 +1,74 @@
+module.exports = function (context) {
+  const sourceCode = context.getSourceCode();
+  let previousDeclaration = null;
+
+  /**
+   * Gets the local name of the first imported module.
+   * @param {ASTNode} node - the ImportDeclaration node.
+   * @returns {?string} the local name of the first imported module.
+   */
+  function getFirstLocalMemberName(node) {
+    if (node.specifiers[0]) {
+      return node.specifiers[0].local.name.toLowerCase();
+    }
+    return null;
+
+  }
+
+  return {
+    ImportDeclaration(node) {
+      if (previousDeclaration) {
+        let currentLocalMemberName = getFirstLocalMemberName(node),
+          previousLocalMemberName = getFirstLocalMemberName(previousDeclaration);
+
+        if (previousLocalMemberName &&
+          currentLocalMemberName &&
+          currentLocalMemberName < previousLocalMemberName
+        ) {
+          context.report({
+            node,
+            message: "Imports should be sorted alphabetically."
+          });
+        }
+      }
+
+      const importSpecifiers = node.specifiers.filter(specifier => specifier.type === "ImportSpecifier");
+      const getSortableName = specifier => specifier.local.name.toLowerCase();
+      const firstUnsortedIndex = importSpecifiers.map(getSortableName).findIndex((name, index, array) => array[index - 1] > name);
+
+      if (firstUnsortedIndex !== -1) {
+        context.report({
+          node: importSpecifiers[firstUnsortedIndex],
+          message: "Member '{{memberName}}' of the import declaration should be sorted alphabetically.",
+          data: { memberName: importSpecifiers[firstUnsortedIndex].local.name },
+          fix(fixer) {
+            return fixer.replaceTextRange(
+              [importSpecifiers[0].range[0], importSpecifiers[importSpecifiers.length - 1].range[1]],
+              importSpecifiers
+                // Clone the importSpecifiers array to avoid mutating it
+                .slice()
+
+                // Sort the array into the desired order
+                .sort((specifierA, specifierB) => {
+                  const aName = getSortableName(specifierA);
+                  const bName = getSortableName(specifierB);
+                  return aName > bName ? 1 : -1;
+                })
+
+                // Build a string out of the sorted list of import specifiers and the text between the originals
+                .reduce((sourceText, specifier, index) => {
+                  const textAfterSpecifier = index === importSpecifiers.length - 1
+                    ? ""
+                    : sourceCode.getText().slice(importSpecifiers[index].range[1], importSpecifiers[index + 1].range[0]);
+
+                  return sourceText + sourceCode.getText(specifier) + textAfterSpecifier;
+                }, "")
+            );
+          }
+        });
+      }
+
+      previousDeclaration = node;
+    }
+  };
+};


### PR DESCRIPTION
Built-in version of this doesn’t quite do what we wanted so I customized it. Rule is that the first imported item of each line must be in sorted order, and multi-item imports must be sorted as well. Case insensitive.

This is good: 

```javascript
import {assert, expect} from 'chai';
import React from 'react';
import * as utils from './utils';
import 'test.styl';
```